### PR TITLE
Added Edit menu

### DIFF
--- a/electron-main.ts
+++ b/electron-main.ts
@@ -25,6 +25,17 @@ function createMenu(): void {
             ]
         },
         {
+            label: 'Edit',
+            submenu: [
+                { role: 'undo' },
+                { role: 'redo' },
+                { type: 'separator' },
+                { role: 'cut' },
+                { role: 'copy' },
+                { role: 'paste' }
+            ]
+        },
+        {
             label: 'View',
             submenu: [{ role: 'togglefullscreen' }, { role: 'toggleDevTools' }]
         },


### PR DESCRIPTION
Enable copy and paste using macOS requires an application’s menu with keybindings to the native clipboard.